### PR TITLE
Add qsuffix=cpp=f flag compile flag to fix IBM BG compilation issue.

### DIFF
--- a/phSolver/incompressible/CMakeLists.txt
+++ b/phSolver/incompressible/CMakeLists.txt
@@ -45,6 +45,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES XL)
 	#force preprocessing of solfar.f
 	set_source_files_properties(solfar.f PROPERTIES COMPILE_FLAGS "-qsuffix=cpp=f")
 	set_source_files_properties(itrdrv.f PROPERTIES COMPILE_FLAGS "-qsuffix=cpp=f")
+	set_source_files_properties(filters.f PROPERTIES COMPILE_FLAGS "-qsuffix=cpp=f")
 endif(CMAKE_Fortran_COMPILER_ID MATCHES XL)
 if(CMAKE_Fortran_COMPILER_ID MATCHES PGI)
 	#force preprocessing of solfar.f


### PR DESCRIPTION
It appears that the "-qsuffix=cpp=f" compile flag is needed on
phSolver/incompressible/filters.f to process the #ifdef HAVE_LESLIB
macro.
